### PR TITLE
Fix handling names with spaces

### DIFF
--- a/inotifywaitgo/command.go
+++ b/inotifywaitgo/command.go
@@ -17,6 +17,7 @@ func GenerateBashCommands(s *Settings) ([]string, error) {
 
 	baseCmd := []string{
 		"inotifywait",
+		"-c", // switch to CSV output
 	}
 
 	if s.Options.Monitor {

--- a/inotifywaitgo/command.go
+++ b/inotifywaitgo/command.go
@@ -34,8 +34,7 @@ func GenerateBashCommands(s *Settings) ([]string, error) {
 			if !Contains(VALID_EVENTS, int(event)) {
 				return nil, errors.New(INVALID_EVENT)
 			}
-			baseCmd = append(baseCmd, "-e ")
-			baseCmd = append(baseCmd, EVENT_MAP[int(event)])
+			baseCmd = append(baseCmd, "-e ", EVENT_MAP[int(event)])
 		}
 	}
 

--- a/inotifywaitgo/command.go
+++ b/inotifywaitgo/command.go
@@ -28,18 +28,18 @@ func GenerateBashCommands(s *Settings) ([]string, error) {
 		baseCmd = append(baseCmd, "-r")
 	}
 
-	baseCmd = append(baseCmd, s.Dir)
-
 	if len(s.Options.Events) > 0 {
-		baseCmd = append(baseCmd, "-e")
 		for _, event := range s.Options.Events {
 			// if event not in VALID_EVENTS
 			if !Contains(VALID_EVENTS, int(event)) {
 				return nil, errors.New(INVALID_EVENT)
 			}
-			baseCmd = append(baseCmd, EVENT_MAP[int(event)]+" ")
+			baseCmd = append(baseCmd, "-e ")
+			baseCmd = append(baseCmd, EVENT_MAP[int(event)])
 		}
 	}
+
+	baseCmd = append(baseCmd, s.Dir)
 
 	// remove spaces on all elements
 	var outCmd []string

--- a/inotifywaitgo/watcher.go
+++ b/inotifywaitgo/watcher.go
@@ -2,6 +2,7 @@ package inotifywaitgo
 
 import (
 	"bufio"
+	"encoding/csv"
 	"fmt"
 	"log"
 	"os"
@@ -54,8 +55,11 @@ func WatchPath(s *Settings) {
 	for scanner.Scan() {
 		log.Println(scanner.Text())
 		line := scanner.Text()
-		parts := strings.Split(line, " ")
-		if len(parts) < 2 {
+
+		r := csv.NewReader(strings.NewReader(line))
+
+		parts, err := r.Read()
+		if err != nil || len(parts) < 2 {
 			s.ErrorChan <- fmt.Errorf(INVALID_OUTPUT)
 			continue
 		}


### PR DESCRIPTION
This PR fixes problems when parsing output with spaces in directory and file names.
It also fixed the cmdline when specifying mulltiple events to listen to.