### PR TITLE
Handle inotify isdir flag

### DIFF
--- a/inotifywaitgo/models.go
+++ b/inotifywaitgo/models.go
@@ -59,6 +59,9 @@ const (
 	EventDeleteSelf = "delete_self"
 	// The  filesystem  on  which  a  watched  file or directory resides was unmounted.  After this event the file or directory is no longer being 	watched.  Note that this event can occur even if it is not explicitly being listened to.
 	EventUnmount = "unmount"
+
+	// The subject of this event is a directory
+	FlagIsdir = "ISDIR"
 )
 
 type EVENT int
@@ -84,6 +87,7 @@ const (
 type FileEvent struct {
 	Filename string
 	Events   []EVENT
+	IsDir    bool
 }
 
 var EVENT_MAP = map[int]string{

--- a/inotifywaitgo/watcher.go
+++ b/inotifywaitgo/watcher.go
@@ -75,8 +75,14 @@ func WatchPath(s *Settings) {
 			}
 		}
 		var eventsEvents []EVENT
+		isDir := false
 
 		for _, eventStr := range eventsStr {
+			if eventStr == FlagIsdir {
+				isDir = true
+				continue
+			}
+
 			eventStr = strings.ToLower(eventStr)
 			event, ok := EVENT_MAP_REVERSE[eventStr]
 			if !ok {
@@ -89,6 +95,7 @@ func WatchPath(s *Settings) {
 		event := FileEvent{
 			Filename: prefix + file,
 			Events:   eventsEvents,
+			IsDir:    isDir,
 		}
 
 		// Send the file name to the channel


### PR DESCRIPTION
This PR adds a field to`FileEvent` which holds the value of the inotify `IN_ISDIR` flag.

This fixes errors when working with directories like

 ```
Error: invalid eventStr: <isdir>, </path/to/,"CREATE,ISDIR",dir>
```