### PR TITLE
Move log behind verbose flag

### DIFF
--- a/inotifywaitgo/watcher.go
+++ b/inotifywaitgo/watcher.go
@@ -53,7 +53,10 @@ func WatchPath(s *Settings) {
 	scanner := bufio.NewScanner(stdout)
 	for scanner.Scan() {
 		line := scanner.Text()
-		log.Println(line)
+
+		if s.Verbose {
+			log.Println(line)
+		}
 
 		parts, err := parseLine(line)
 		if err != nil || len(parts) < 2 {


### PR DESCRIPTION
Hey! Thanks for the project :)

There's a log for filesystem events which was being made with the verbose flag off - I moved it behind the flag. 