### PR TITLE
Use a slog logger to log

### DIFF
--- a/example/main.go
+++ b/example/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"log"
+	"log/slog"
 
 	"github.com/pablodz/inotifywaitgo/inotifywaitgo"
 )
@@ -24,6 +25,7 @@ func main() {
 			Monitor: true,
 		},
 		Verbose: true,
+		Log:     slog.Default(),
 	})
 
 loopFiles:

--- a/inotifywaitgo/models.go
+++ b/inotifywaitgo/models.go
@@ -1,5 +1,7 @@
 package inotifywaitgo
 
+import "log/slog"
+
 type Settings struct {
 	// Directory to watch
 	Dir string
@@ -13,6 +15,8 @@ type Settings struct {
 	KillOthers bool
 	// verbose
 	Verbose bool
+	// Logger
+	Log *slog.Logger
 }
 
 type Options struct {

--- a/inotifywaitgo/watcher.go
+++ b/inotifywaitgo/watcher.go
@@ -5,6 +5,7 @@ import (
 	"encoding/csv"
 	"errors"
 	"fmt"
+	"log/slog"
 	"os"
 	"os/exec"
 	"strings"
@@ -49,11 +50,16 @@ func WatchPath(s *Settings) {
 		return
 	}
 
+	logger := s.Log
+	if logger == nil {
+		logger = slog.New(slog.NewTextHandler(os.Stdout, nil))
+	}
+
 	// Read the output of inotifywait and split it into lines
 	scanner := bufio.NewScanner(stdout)
 	for scanner.Scan() {
 		line := scanner.Text()
-		s.Log.Debug(line)
+		logger.Debug(line)
 
 		parts, err := parseLine(line)
 		if err != nil || len(parts) < 2 {
@@ -66,7 +72,7 @@ func WatchPath(s *Settings) {
 
 		if s.Verbose {
 			for _, eventStr := range eventStrs {
-				s.Log.Debug("eventStr: <%s>, <%s>", eventStr, line)
+				logger.Debug("eventStr: <%s>, <%s>", eventStr, line)
 			}
 		}
 

--- a/inotifywaitgo/watcher.go
+++ b/inotifywaitgo/watcher.go
@@ -5,7 +5,6 @@ import (
 	"encoding/csv"
 	"errors"
 	"fmt"
-	"log"
 	"os"
 	"os/exec"
 	"strings"
@@ -54,7 +53,7 @@ func WatchPath(s *Settings) {
 	scanner := bufio.NewScanner(stdout)
 	for scanner.Scan() {
 		line := scanner.Text()
-		log.Println(line)
+		s.Log.Debug(line)
 
 		parts, err := parseLine(line)
 		if err != nil || len(parts) < 2 {
@@ -67,7 +66,7 @@ func WatchPath(s *Settings) {
 
 		if s.Verbose {
 			for _, eventStr := range eventStrs {
-				log.Printf("eventStr: <%s>, <%s>", eventStr, line)
+				s.Log.Debug("eventStr: <%s>, <%s>", eventStr, line)
 			}
 		}
 


### PR DESCRIPTION
This PR adds a slog logger to the Settings struct which can be used to pass in a Logger that is used by the module.

If no Logger is set, a default logger is created that mimics the old behavior hopefully.