### PR TITLE
Remove unecessary logging

### DIFF
--- a/inotifywaitgo/watcher.go
+++ b/inotifywaitgo/watcher.go
@@ -54,7 +54,6 @@ func WatchPath(s *Settings) {
 	scanner := bufio.NewScanner(stdout)
 	for scanner.Scan() {
 		line := scanner.Text()
-		log.Println(line)
 
 		parts, err := parseLine(line)
 		if err != nil || len(parts) < 2 {


### PR DESCRIPTION
Removed a println that prints output from the inotifywait buffer since we already handling printing the output using verbose option.